### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ sudo nano /boot/config.txt
 
 * Add these lines in the bottom of the file:
 ```
+[all]
 dtoverlay=disable-bt
 
 # MKS TS35


### PR DESCRIPTION
O arquivo `/boot/config.txt` veio com a seguinte configuração no final do arquivo:

```
[cm4]
# Enable host mode on the 2711 built-in XHCI USB controller.
# This line should be removed if the legacy DWC2 controller is required
# (e.g. for USB device mode) or if USB support is not required.
otg_mode=1

[pi4]
# Run as fast as firmware / board allows
arm_boost=1
```

Sendo assim, a configuração adicionada entra no contexto `[pi4]`, não no `[all]`.
A solução seria colocar a configuração antes desses dois contextos que citei acima, pois antes deles estamos no contexto `[all]` ou simplesmente adicionar uma linha mudando o contexto para `[all]` novamente antes de adicionar o código.

Estou usando um Resberry Pi 3 Model B V1.2
Estou usando a distribuição do [Raspios Lite 64-bit do dia 22/02/2023](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2023-02-22/) com o Kernel 1.15